### PR TITLE
Fix filtering Hit model by ip to include the HitCount model instance

### DIFF
--- a/hitcount/managers/hits.py
+++ b/hitcount/managers/hits.py
@@ -43,7 +43,7 @@ class HitManager(models.Manager):
         period = timezone.now() - timedelta(**grace)
         return self.filter(created__gte=period).filter(*args, **kwargs)
 
-    def has_limit_reached_by_ip(self, ip=None, hitcount=None):
+    def has_limit_reached_by_ip(self, ip, hitcount):
         hits_per_ip_limit = settings.HITCOUNT_HITS_PER_IP_LIMIT
         if not ip or not hits_per_ip_limit:
             return False

--- a/hitcount/managers/hits.py
+++ b/hitcount/managers/hits.py
@@ -43,12 +43,12 @@ class HitManager(models.Manager):
         period = timezone.now() - timedelta(**grace)
         return self.filter(created__gte=period).filter(*args, **kwargs)
 
-    def has_limit_reached_by_ip(self, ip=None):
+    def has_limit_reached_by_ip(self, ip=None, hitcount=None):
         hits_per_ip_limit = settings.HITCOUNT_HITS_PER_IP_LIMIT
         if not ip or not hits_per_ip_limit:
             return False
 
-        return self.filter_active(ip=ip).count() >= hits_per_ip_limit
+        return self.filter_active(ip=ip, hitcount=hitcount).count() >= hits_per_ip_limit
 
     def has_limit_reached_by_session(self, session, hitcount):
         hits_per_session_limit = settings.HITCOUNT_HITS_PER_SESSION_LIMIT

--- a/hitcount/mixins.py
+++ b/hitcount/mixins.py
@@ -85,7 +85,7 @@ class HitCountViewMixin:
         # active hits to see if we should count another one
 
         # check limit on hits from a unique ip address (HITCOUNT_HITS_PER_IP_LIMIT)
-        if Hit.objects.has_limit_reached_by_ip(ip):
+        if Hit.objects.has_limit_reached_by_ip(ip, hitcount):
             return UpdateHitCountResponse(
                 False, 'Not counted: hits per IP address limit reached')
 

--- a/tests/test_managers/test_hits.py
+++ b/tests/test_managers/test_hits.py
@@ -44,14 +44,14 @@ class TestHitManager(TestCase):
 
         # all hits are counted.
         with patch.object(settings, 'HITCOUNT_HITS_PER_IP_LIMIT', 0):
-            self.assertIs(Hit.objects.has_limit_reached_by_ip(), False)
+            self.assertIs(Hit.objects.has_limit_reached_by_ip(None, self.hitcount), False)
 
             Hit.objects.create(hitcount=self.hitcount, ip=ip)
 
-            self.assertIs(Hit.objects.has_limit_reached_by_ip(ip), False)
+            self.assertIs(Hit.objects.has_limit_reached_by_ip(ip, self.hitcount), False)
 
         with patch.object(settings, 'HITCOUNT_HITS_PER_IP_LIMIT', 2):
-            self.assertIs(Hit.objects.has_limit_reached_by_ip(ip), True)
+            self.assertIs(Hit.objects.has_limit_reached_by_ip(ip, self.hitcount), True)
 
     def test_has_limit_reached_by_session(self):
         request = RequestFactory()


### PR DESCRIPTION
include the HitCount model instance in the has_limit_reached_by_ip method to filter the Hit model by the IP and HitCount instance as it is done in the has_limit_reached_by_session method